### PR TITLE
Fix/update GitHub repository URLs to reflect new organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Welcome to **Laravel Hub**, an open-source platform that helps developers discover and explore packages and libraries across different programming languages and frameworks.
 
 <!-- TODO: uncomment later -->
-<!-- [![GitHub stars](https://img.shields.io/github/stars/LaravelHub/laravel-hub?style=social)](https://github.com/theLaravelHub/laravel-hub)
-[![GitHub forks](https://img.shields.io/github/forks/LaravelHub/laravel-hub?style=social)](https://github.com/theLaravelHub/laravel-hub) -->
+<!-- [![GitHub stars](https://img.shields.io/github/stars/TheLaravelHub/laravel-hub?style=social)](https://github.com/theLaravelHub/laravel-hub)
+[![GitHub forks](https://img.shields.io/github/forks/TheLaravelHub/laravel-hub?style=social)](https://github.com/theLaravelHub/laravel-hub) -->
 
 🔗 **Project Link:** [Laravel-Hub.com](https://laravel-hub.com)
 

--- a/resources/js/components/shared/cta-section.tsx
+++ b/resources/js/components/shared/cta-section.tsx
@@ -81,7 +81,7 @@ const CTASection = () => {
                             className="flex items-center gap-2"
                         >
                             <a
-                                href="https://github.com/LaravelHub/laravel-hub/discussions/new?category=package-submission"
+                                href="https://github.com/TheLaravelHub/laravel-hub/discussions/new?category=package-submission"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 onClick={handlePackageSubmissionLinkClick}
@@ -103,7 +103,7 @@ const CTASection = () => {
                             className="flex items-center gap-2"
                         >
                             <a
-                                href="https://github.com/LaravelHub/laravel-hub"
+                                href="https://github.com/TheLaravelHub/laravel-hub"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 onClick={handleStarOnGithubClick}

--- a/resources/js/components/shared/navbar.tsx
+++ b/resources/js/components/shared/navbar.tsx
@@ -247,7 +247,7 @@ const Navbar = () => {
                                     className="w-full justify-start"
                                 >
                                     <a
-                                        href="https://github.com/LaravelHub/laravel-hub/discussions/new?category=package-submission"
+                                        href="https://github.com/TheLaravelHub/laravel-hub/discussions/new?category=package-submission"
                                         target={'_blank'}
                                         className="flex items-center space-x-2"
                                     >


### PR DESCRIPTION
This pull request fixes **404** errors by updating outdated links from [LaravelHub/laravel-hub](https://github.com/LaravelHub/laravel-hub) to the new repository URL: [TheLaravelHub/laravel-hub](https://github.com/TheLaravelHub/laravel-hub)