### PR TITLE
fix: Update default image URL logic and optimize package searchability

### DIFF
--- a/app/Filament/Resources/PackageSubmissionResource.php
+++ b/app/Filament/Resources/PackageSubmissionResource.php
@@ -36,8 +36,9 @@ class PackageSubmissionResource extends Resource
                 Tables\Columns\ImageColumn::make('user.avatar_url')
                     ->label('')
                     ->circular()
-                    ->defaultImageUrl(function ($record) {
-                        $initials = substr($record->name, 0, 2);
+                    ->defaultImageUrl(function (PackageSubmission $record) {
+                        $name = $record->user?->name ?? 'User';
+                        $initials = mb_substr(preg_replace('/\s+/', '', $name), 0, 2) ?: 'UH';
 
                         return 'https://ui-avatars.com/api/?name='.urlencode($initials).'&color=FFFFFF&background=111827';
                     })

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -58,7 +58,7 @@ class PackageController extends Controller
 
             $package->categories()->sync($request->category_ids);
 
-            $package->get()->searchable();
+            $package->searchable();
 
             DB::commit();
 


### PR DESCRIPTION
`app/Filament/Resources/PackageSubmissionResource.php`: derive avatar fallback initials from the related submitter to avoid undefined-property warnings and keep Filament avatars consistent.

`app/Http/Controllers/Admin/PackageController.php`: invoke Scout’s `searchable()` directly on the new package so creation no longer reindexes the entire packages table.
